### PR TITLE
stream: Fix parallel issues

### DIFF
--- a/src/mongo-read-stream.ts
+++ b/src/mongo-read-stream.ts
@@ -95,6 +95,7 @@ export class MongoReadStream<T extends BaseMongoObject, U extends BaseMongoObjec
 	}
 
 	public async _read(size: number): Promise<void> {
+		this.pause();
 		if (this.first) {
 			this.first = false;
 		} else {
@@ -106,9 +107,8 @@ export class MongoReadStream<T extends BaseMongoObject, U extends BaseMongoObjec
 		let item = null;
 		while (await cursor.hasNext()) {
 			resultLength++;
-
 			item = await cursor.next();
-			if (item != null) this.push(item);
+			if (item) this.push(item);
 		}
 		if (item != null) {
 			this.lastId = item._id;
@@ -117,6 +117,7 @@ export class MongoReadStream<T extends BaseMongoObject, U extends BaseMongoObjec
 		if (resultLength < this.pageSize) {
 			this.push(null);
 		}
+		this.resume();
 	}
 
 }


### PR DESCRIPTION
This pull request contains a fix for theh `MongoReadStream` class that prevent concurrent reads to happens. Concurrent reads are not supported because each read is dependant on the result of the previous read (we need the last _id of each read).